### PR TITLE
Receive a registry as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This module has a peer dependency on [`prom-client`](https://github.com/siimon/p
 This module follows the same API as the core default metrics. To start collection GC stats, invoke the exported function to create the
 metrics, then invoke the returned function to start the collecting.
 
+The exported function takes a single parameter, which is a registry. If provided, and the version of prom-client you use support it, that is
+the registry which the metrics will register to.
+
 ### `gc-stats`
 
 The module doing the GC stats collecting is [`gc-stats`](https://github.com/dainis/node-gcstats). This module requires native dependencies.

--- a/gc-metrics.js
+++ b/gc-metrics.js
@@ -1,7 +1,12 @@
 // Credits go to @tcolgate
 
 import Counter from 'prom-client/lib/counter';
+import { version } from 'prom-client/package.json';
 import optional from 'optional';
+
+const promMajor = Number(version.split('.')[0]);
+
+const promSupportsRegistries = promMajor >= 9;
 
 const gc = optional('gc-stats');
 
@@ -17,16 +22,55 @@ const gcTypes = {
 
 const noop = () => {};
 
-export default () => {
+export default registry => {
   if (typeof gc !== 'function') {
     return noop;
   }
 
-  const gcCount = new Counter('nodejs_gc_runs_total', 'Count of total garbage collections.', ['gctype']);
-  const gcTimeCount = new Counter('nodejs_gc_pause_seconds_total', 'Time spent in GC Pause in seconds.', ['gctype']);
-  const gcReclaimedCount = new Counter('nodejs_gc_reclaimed_bytes_total', 'Total number of bytes reclaimed by GC.', [
-    'gctype',
-  ]);
+  let gcCount;
+  let gcTimeCount;
+  let gcReclaimedCount;
+
+  if (registry) {
+    if (!promSupportsRegistries) {
+      throw new Error(
+        "You've provided a registry, but your version of prom-client is too old. Please use prom-client@9 or higher"
+      );
+    }
+
+    const registers = [registry];
+    const labelNames = ['gctype'];
+
+    gcCount = new Counter({
+      name: 'nodejs_gc_runs_total',
+      help: 'Count of total garbage collections.',
+      labelNames,
+      registers,
+    });
+    gcTimeCount = new Counter({
+      name: 'nodejs_gc_pause_seconds_total',
+      help: 'Time spent in GC Pause in seconds.',
+      labelNames,
+      registers,
+    });
+    gcReclaimedCount = new Counter({
+      name: 'nodejs_gc_reclaimed_bytes_total',
+      help: 'Total number of bytes reclaimed by GC.',
+      labelNames,
+      registers,
+    });
+  } else {
+    gcCount = new Counter(
+      'nodejs_gc_runs_total',
+      'Count of total garbage collections.',
+      ['gctype'],
+      registry && [registry]
+    );
+    gcTimeCount = new Counter('nodejs_gc_pause_seconds_total', 'Time spent in GC Pause in seconds.', ['gctype']);
+    gcReclaimedCount = new Counter('nodejs_gc_reclaimed_bytes_total', 'Total number of bytes reclaimed by GC.', [
+      'gctype',
+    ]);
+  }
 
   let started = false;
 


### PR DESCRIPTION
Alternative to #19.

@Crevil could you test it out?

Compiled code for pasting:
```js
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});

var _counter = require("prom-client/lib/counter");

var _counter2 = _interopRequireDefault(_counter);

var _package = require("prom-client/package.json");

var _optional = require("optional");

var _optional2 = _interopRequireDefault(_optional);

function _interopRequireDefault(obj) {
  return obj && obj.__esModule ? obj : { default: obj };
}

var promMajor = Number(_package.version.split(".")[0]); // Credits go to @tcolgate

var promSupportsRegistries = promMajor >= 9;

var gc = (0, _optional2.default)("gc-stats");

var gcTypes = {
  0: "Unknown",
  1: "Scavenge",
  2: "MarkSweepCompact",
  3: "ScavengeAndMarkSweepCompact",
  4: "IncrementalMarking",
  8: "WeakPhantom",
  15: "All"
};

var noop = function noop() {};

exports.default = function(registry) {
  if (typeof gc !== "function") {
    return noop;
  }

  var gcCount = void 0;
  var gcTimeCount = void 0;
  var gcReclaimedCount = void 0;

  if (registry) {
    if (!promSupportsRegistries) {
      throw new Error(
        "You've provided a registry, but your version of prom-client is too old. Please use prom-client@9 or higher"
      );
    }

    var registers = [registry];
    var labelNames = ["gctype"];

    gcCount = new _counter2.default({
      name: "nodejs_gc_runs_total",
      help: "Count of total garbage collections.",
      labelNames: labelNames,
      registers: registers
    });
    gcTimeCount = new _counter2.default({
      name: "nodejs_gc_pause_seconds_total",
      help: "Time spent in GC Pause in seconds.",
      labelNames: labelNames,
      registers: registers
    });
    gcReclaimedCount = new _counter2.default({
      name: "nodejs_gc_reclaimed_bytes_total",
      help: "Total number of bytes reclaimed by GC.",
      labelNames: labelNames,
      registers: registers
    });
  } else {
    gcCount = new _counter2.default(
      "nodejs_gc_runs_total",
      "Count of total garbage collections.",
      ["gctype"],
      registry && [registry]
    );
    gcTimeCount = new _counter2.default(
      "nodejs_gc_pause_seconds_total",
      "Time spent in GC Pause in seconds.",
      ["gctype"]
    );
    gcReclaimedCount = new _counter2.default(
      "nodejs_gc_reclaimed_bytes_total",
      "Total number of bytes reclaimed by GC.",
      ["gctype"]
    );
  }

  var started = false;

  return function() {
    if (started !== true) {
      started = true;

      gc().on("stats", function(stats) {
        var gcType = gcTypes[stats.gctype];

        gcCount.labels(gcType).inc();
        gcTimeCount.labels(gcType).inc(stats.pause / 1e9);

        if (stats.diff.usedHeapSize < 0) {
          gcReclaimedCount.labels(gcType).inc(stats.diff.usedHeapSize * -1);
        }
      });
    }
  };
};

module.exports = exports["default"];
```