### PR TITLE
Fix code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const prometheus = require('prom-client');
 const gcStats = require('prometheus-gc-stats');
 
 prometheus.collectDefaultMetrics();
-const startGcStats = gcStats(prometheus.registry); // gcStats() would have the same effect in this case
+const startGcStats = gcStats(prometheus.register); // gcStats() would have the same effect in this case
 startGcStats();
 ```
 


### PR DESCRIPTION
The default registry is called `register` in prom-client