### PR TITLE
Add node 10 to CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
       - node-v4
       - node-v6
       - node-v8
+      - node-v10
 version: 2
 jobs:
   node-base: &node-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,3 +60,7 @@ jobs:
     <<: *node-base
     docker:
       - image: node:8
+  node-v10:
+    <<: *node-base
+    docker:
+      - image: node:10


### PR DESCRIPTION
I've got a project that uses this library and builds on node 10 in travis which is [failing](https://travis-ci.org/trussle/tricorder/jobs/387048086). To understand if it's an issue with gc-stats or my own library I've updated the CI setup to include testing for node version 10. 