### PR TITLE
Aggregate as an average (instead of default sum) when in a cluster

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,18 +33,21 @@ module.exports = (registry, config = {}) => {
   const gcCount = new Counter({
     name: `${namePrefix}nodejs_gc_runs_total`,
     help: 'Count of total garbage collections.',
+    aggregator: 'average',
     labelNames,
     registers,
   });
   const gcTimeCount = new Counter({
     name: `${namePrefix}nodejs_gc_pause_seconds_total`,
     help: 'Time spent in GC Pause in seconds.',
+    aggregator: 'average',
     labelNames,
     registers,
   });
   const gcReclaimedCount = new Counter({
     name: `${namePrefix}nodejs_gc_reclaimed_bytes_total`,
     help: 'Total number of bytes reclaimed by GC.',
+    aggregator: 'average',
     labelNames,
     registers,
   });


### PR DESCRIPTION
Firstly, thank you for this library.

prom-client added functionality to aggregate metrics across multiple workers in a cluster. By default it aggregates by summing the metrics of each worker. I couldn't see any mention of aggregation in this codebase so I assumed (and please correct me if I'm wrong) that this functionality hasn't been needed by yourself or any consumers so it was overlooked.

I believe that average (mean) is more appropriate for these metrics and so I have added this functionality. If you think that average is incorrect or that there are valid use-cases for the other aggregations I am happy to make it configurable.