### PR TITLE
feat: add support for v8 version 10+

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,29 @@ const optional = require('optional');
 
 const gc = optional('gc-stats');
 
-const gcTypes = {
-  0: 'Unknown',
-  1: 'Scavenge',
-  2: 'MarkSweepCompact',
-  3: 'ScavengeAndMarkSweepCompact',
-  4: 'IncrementalMarking',
-  8: 'WeakPhantom',
-  15: 'All',
-};
+const v8Version = process.versions.v8;
+const v8MajorVersion = Number(v8Version.split('.')[0]);
+
+const gcTypes = v8MajorVersion < 10
+  ? {
+    // https://github.com/nodejs/node/blob/554fa24916c5c6d052b51c5cee9556b76489b3f7/deps/v8/include/v8.h#L6137-L6144
+    0: 'Unknown',
+    1: 'Scavenge',
+    2: 'MarkSweepCompact',
+    3: 'ScavengeAndMarkSweepCompact',
+    4: 'IncrementalMarking',
+    8: 'WeakPhantom',
+    15: 'All',
+  } : {
+    // https://github.com/nodejs/node/blob/ccd3a42dd9ea2132111610e667ee338618e3b101/deps/v8/include/v8-callbacks.h#L150-L159
+    0: 'Unknown',
+    1: 'Scavenge',
+    2: 'MinorMarkCompact',
+    4: 'MarkSweepCompact',
+    8: 'IncrementalMarking',
+    16: 'ProcessWeakCallbacks',
+    31: 'All',
+  };
 
 const noop = () => {};
 

--- a/index.js
+++ b/index.js
@@ -10,26 +10,28 @@ const gc = optional('gc-stats');
 const v8Version = process.versions.v8;
 const v8MajorVersion = Number(v8Version.split('.')[0]);
 
-const gcTypes = v8MajorVersion < 10
-  ? {
-    // https://github.com/nodejs/node/blob/554fa24916c5c6d052b51c5cee9556b76489b3f7/deps/v8/include/v8.h#L6137-L6144
-    0: 'Unknown',
-    1: 'Scavenge',
-    2: 'MarkSweepCompact',
-    3: 'ScavengeAndMarkSweepCompact',
-    4: 'IncrementalMarking',
-    8: 'WeakPhantom',
-    15: 'All',
-  } : {
-    // https://github.com/nodejs/node/blob/ccd3a42dd9ea2132111610e667ee338618e3b101/deps/v8/include/v8-callbacks.h#L150-L159
-    0: 'Unknown',
-    1: 'Scavenge',
-    2: 'MinorMarkCompact',
-    4: 'MarkSweepCompact',
-    8: 'IncrementalMarking',
-    16: 'ProcessWeakCallbacks',
-    31: 'All',
-  };
+const gcTypes =
+  v8MajorVersion < 10
+    ? {
+        // https://github.com/nodejs/node/blob/554fa24916c5c6d052b51c5cee9556b76489b3f7/deps/v8/include/v8.h#L6137-L6144
+        0: 'Unknown',
+        1: 'Scavenge',
+        2: 'MarkSweepCompact',
+        3: 'ScavengeAndMarkSweepCompact',
+        4: 'IncrementalMarking',
+        8: 'WeakPhantom',
+        15: 'All',
+      }
+    : {
+        // https://github.com/nodejs/node/blob/ccd3a42dd9ea2132111610e667ee338618e3b101/deps/v8/include/v8-callbacks.h#L150-L159
+        0: 'Unknown',
+        1: 'Scavenge',
+        2: 'MinorMarkCompact',
+        4: 'MarkSweepCompact',
+        8: 'IncrementalMarking',
+        16: 'ProcessWeakCallbacks',
+        31: 'All',
+      };
 
 const noop = () => {};
 


### PR DESCRIPTION
After upgrading from Node 16 to Node 18 I noticed that I get some `undefined`s in the `gctype` label in my prometheus metrics:
```
koa_nodejs_gc_runs_total{gctype="Scavenge"} 3618
koa_nodejs_gc_runs_total{gctype="WeakPhantom"} 482
koa_nodejs_gc_runs_total{gctype="IncrementalMarking"} 241
koa_nodejs_gc_runs_total{gctype="undefined"} 2877
```

After digging into this a bit, I found out that the `GCType` enum was changed in v8 in version 10 in [this PR](https://github.com/nodejs/node/commit/974ab4060fe3eff74dc0a62a5a27d516738f4c55#diff-6cd547dfc8c9b2a037e7c25c53b4a227a740a128ab2b837c005a1e0c0eaee431) (check `deps/v8/include/v8-callbacks.h`):

Before:
https://github.com/nodejs/node/blob/554fa24916c5c6d052b51c5cee9556b76489b3f7/deps/v8/include/v8.h#L6137-L6144

```h
enum GCType {
  kGCTypeScavenge = 1 << 0,
  kGCTypeMarkSweepCompact = 1 << 1,
  kGCTypeIncrementalMarking = 1 << 2,
  kGCTypeProcessWeakCallbacks = 1 << 3,
  kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
               kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
};
```

After:
https://github.com/nodejs/node/blob/main/deps/v8/include/v8-callbacks.h#L150-L159

```h
enum GCType {
  kGCTypeScavenge = 1 << 0,
  kGCTypeMinorMarkCompact = 1 << 1,
  kGCTypeMarkSweepCompact = 1 << 2,
  kGCTypeIncrementalMarking = 1 << 3,
  kGCTypeProcessWeakCallbacks = 1 << 4,
  kGCTypeAll = kGCTypeScavenge | kGCTypeMinorMarkCompact |
               kGCTypeMarkSweepCompact | kGCTypeIncrementalMarking |
               kGCTypeProcessWeakCallbacks
};
```

I made some changes to be able to support both 10+ and <10 versions of v8 with proper GC type mappings.

Let me know what you think.